### PR TITLE
Add #[repr(C)] to AllocateType

### DIFF
--- a/uefi/src/table/boot.rs
+++ b/uefi/src/table/boot.rs
@@ -1585,6 +1585,7 @@ impl<'a, P: Protocol + ?Sized> ScopedProtocol<'a, P> {
 }
 
 /// Type of allocation to perform.
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub enum AllocateType {
     /// Allocate any possible pages.


### PR DESCRIPTION
EFI_ALLOCATE_TYPE is a C enum (https://uefi.org/specs/UEFI/2.10/07_Services_Boot_Services.html?highlight=efi_allocate_type#efi-boot-services-allocatepages), and it's used in protocols such as the PCI Root Bridge I/O protocol (https://uefi.org/specs/UEFI/2.10/14_Protocols_PCI_Bus_Support.html#efi-pci-root-bridge-io-protocol-allocatebuffer).

Would you like me to add this to the changelog?